### PR TITLE
Support project name or ID

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -28,32 +28,46 @@ xcode-select --install
 </tr>
 </table>
 
-# Available Actions
-### test_list
+### google_api_key_list_allowed_bundle_ids
 ```
-fastlane test_list
+    google_api_key_list_allowed_bundle_ids(
+      project_number: "some:project-id",
+      api_key_id: "fd1d4e87-0ba5-4e2e-bacd-54d96b70befd",
+      type: 'ios',
+      username: ENV['GOOGLE_USERNAME'],
+      password: ENV['GOOGLE_PASSWORD'],
+    )
 ```
-
-### test_add_client
 ```
-fastlane test_add_client
-```
-
-### test_delete_client
-```
-fastlane test_delete_client
-```
-
-### test_upload_certificate
-```
-fastlane test_upload_certificate
-```
-
-### test_download_config
-```
-fastlane test_download_config
+    google_api_key_list_allowed_bundle_ids(
+      project_number: "some:project-id",
+      api_key_id: "fd1d4e87-0ba5-4e2e-bacd-54d96b70befd",
+      type: 'android',
+      username: ENV['GOOGLE_USERNAME'],
+      password: ENV['GOOGLE_PASSWORD'],
+    )
 ```
 
+### google_api_key_add_allowed_bundle_ids
+```
+    google_api_key_add_allowed_bundle_ids(
+      project_number: "some:project-id",
+      api_key_id: "fd1d4e87-0ba5-4e2e-bacd-54d96b70befd",
+      type: 'ios',
+      bundle_id: 'com.example.test',
+      username: ENV['GOOGLE_USERNAME'],
+      password: ENV['GOOGLE_PASSWORD'],
+    )
+    google_api_key_add_allowed_bundle_ids(
+      project_number: "some:project-id",
+      api_key_id: "fd1d4e87-0ba5-4e2e-bacd-54d96b70befd",
+      type: 'android',
+      bundle_id: 'com.example.test',
+      fingerprint: '2a:ae:6c:35:c9:4f:cf:b4:15:db:e9:5f:40:8b:9c:e9:1e:e8:46:ed',
+      username: ENV['GOOGLE_USERNAME'],
+      password: ENV['GOOGLE_PASSWORD'],
+    )
+```
 
 ----
 

--- a/lib/fastlane/plugin/firebase/actions/firebase_get_server_key.rb
+++ b/lib/fastlane/plugin/firebase/actions/firebase_get_server_key.rb
@@ -1,0 +1,98 @@
+module Fastlane
+  module Actions
+    class FirebaseGetServerKeyAction < Action
+      
+      def self.run(params)
+        manager = Firebase::Manager.new
+        #Login
+        api = manager.login(params[:username], params[:password])
+
+        #Select project
+        project = manager.select_project(params[:project_number])
+
+        # Add  team
+        server_key = api.get_server_key(project["projectNumber"])
+
+        UI.success "Successfuly found of server key #{server_key}"
+      end
+
+      def self.description
+        "An unofficial tool to access Firebase"
+      end
+
+      def self.authors
+        ["Jonathan Lewis"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        # Optional:
+        "Firebase helps you list your projects, create applications, download configuration files and more..."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :username,
+                                  env_name: "FIREBASE_USERNAME",
+                               description: "Username for your google account",
+                                  optional: false),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                  env_name: "FIREBASE_PASSWORD",
+                                 sensitive: true,
+                               description: "Password to your firebase account",
+                                  optional: true),
+          FastlaneCore::ConfigItem.new(key: :project_number,
+                                  env_name: "FIREBASE_PROJECT_NUMBER",
+                               description: "Project number",
+                                  optional: true),
+          FastlaneCore::ConfigItem.new(key: :download_config,
+                                  env_name: "FIREBASE_DOWNLOAD_CONFIG",
+                               description: "Should download config for created client",
+                                  optional: false,
+                                  is_string: false,
+                                  default_value: true),
+          FastlaneCore::ConfigItem.new(key: :type,
+                                  env_name: "FIREBASE_TYPE",
+                                  description: "Type of client (ios, android)",
+                                  optional: true),
+          FastlaneCore::ConfigItem.new(key: :bundle_id,
+                                  env_name: "FIREBASE_BUNDLE_ID",
+                               description: "Bundle ID (package name)",
+                                  optional: false),
+          FastlaneCore::ConfigItem.new(key: :name,
+                                  env_name: "FIREBASE_BUNDLE_ID",
+                               description: "Display name",
+                                  optional: true),
+          FastlaneCore::ConfigItem.new(key: :appstore_id,
+                                  env_name: "FIREBASE_APPSTORE_ID",
+                               description: "AppStore ID",
+                                  optional: true),
+          FastlaneCore::ConfigItem.new(key: :output_path,
+                                  env_name: "FIREBASE_OUTPUT_PATH",
+                               description: "Path for the downloaded config",
+                                  optional: false,
+                                  default_value: "./"),
+          FastlaneCore::ConfigItem.new(key: :output_name,
+                                  env_name: "FIREBASE_OUTPUT_NAME",
+                               description: "Name of the downloaded file",
+                                  optional: true),
+          FastlaneCore::ConfigItem.new(key: :team_id,
+                                  env_name: "FIREBASE_TEAM_ID",
+                               description: "ID of the Apple Team",
+                                  optional: false)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        # Adjust this if your plugin only works for a particular platform (iOS vs. Android, for example)
+        # See: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Platforms.md
+        #
+        # [:ios, :mac, :android].include?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/firebase/actions/google_api_key_add_allowed_bundle_ids.rb
+++ b/lib/fastlane/plugin/firebase/actions/google_api_key_add_allowed_bundle_ids.rb
@@ -1,0 +1,78 @@
+require 'base64'
+
+module Fastlane
+  module Actions
+    class GoogleApiKeyAddAllowedBundleIdsAction < Action
+      def self.run(params)
+        manager = Firebase::Manager.new
+        # Login
+        api = manager.login(params[:username], params[:password])
+
+        key_info = api.get_apikey(params[:project_number], params[:api_key_id])
+        case params[:type]
+        when 'ios'
+          key_info['iosKeyDetails']['allowedBundleIds'] << params[:bundle_id]
+          api.update_apikey(params[:project_number], params[:api_key_id], 'apiTargetKeyDetails,iosKeyDetails', key_info)
+        when 'android'
+          key_info['androidKeyDetails']['allowedApplications'] << {
+            packageName: params[:bundle_id],
+            sha1Fingerprint: Base64.strict_encode64([params[:fingerprint].gsub(':','')].pack('H*'))
+          }
+          api.update_apikey(params[:project_number], params[:api_key_id], 'apiTargetKeyDetails,androidKeyDetails', key_info)
+        end
+      end
+
+      def self.description
+        "An unofficial tool to access Firebase"
+      end
+
+      def self.authors
+        ["Jonathan Lewis"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        # Optional:
+        "Get iOS Bundle IDs allowed to access an API Key"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :username,
+                                  env_name: "FIREBASE_USERNAME",
+                               description: "Username for your google account",
+                                  optional: false),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                  env_name: "FIREBASE_PASSWORD",
+                                 sensitive: true,
+                               description: "Password to your firebase account",
+                                  optional: true),
+          FastlaneCore::ConfigItem.new(key: :project_number,
+                                  env_name: "GOOGLE_PROJECT_NUMBER",
+                               description: "Project number",
+                                  optional: false),
+          FastlaneCore::ConfigItem.new(key: :api_key_id,
+                                  env_name: "GOOGLE_API_KEY_ID",
+                               description: "API Key ID to retrieve details for",
+                                  optional: false),
+          FastlaneCore::ConfigItem.new(key: :type,
+                               description: "ios or android",
+                                  optional: false),
+           FastlaneCore::ConfigItem.new(key: :bundle_id,
+                               description: "ios bundle id",
+                                  optional: false),
+           FastlaneCore::ConfigItem.new(key: :fingerprint,
+                               description: "Android SHA-1 fingerprint",
+                                  optional: true)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/firebase/actions/google_api_key_list_allowed_bundle_ids.rb
+++ b/lib/fastlane/plugin/firebase/actions/google_api_key_list_allowed_bundle_ids.rb
@@ -1,0 +1,70 @@
+module Fastlane
+  module Actions
+    class GoogleApiKeyListAllowedBundleIdsAction < Action
+      def self.run(params)
+        manager = Firebase::Manager.new
+        # Login
+        api = manager.login(params[:username], params[:password])
+
+        key_info = api.get_apikey(params[:project_number], params[:api_key_id])
+        case params[:type]
+        when 'ios'
+          key_info['iosKeyDetails']['allowedBundleIds'].each do |bundle|
+            UI.message bundle
+          end
+        when 'android'
+          key_info['androidKeyDetails']['allowedApplications'].each do |app|
+            UI.message app['packageName']
+          end
+        end
+      end
+
+      def self.description
+        "An unofficial tool to access Firebase"
+      end
+
+      def self.authors
+        ["Jonathan Lewis"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        # Optional:
+        "Get iOS Bundle IDs allowed to access an API Key"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :username,
+                                  env_name: "FIREBASE_USERNAME",
+                               description: "Username for your google account",
+                                  optional: false),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                  env_name: "FIREBASE_PASSWORD",
+                                 sensitive: true,
+                               description: "Password to your firebase account",
+                                  optional: true),
+          FastlaneCore::ConfigItem.new(key: :project_number,
+                                  env_name: "GOOGLE_PROJECT_NUMBER",
+                               description: "Project number",
+                                  optional: false),
+          FastlaneCore::ConfigItem.new(key: :api_key_id,
+                                  env_name: "GOOGLE_API_KEY_ID",
+                               description: "API Key ID to retrieve details for",
+                                  optional: false),
+          FastlaneCore::ConfigItem.new(key: :type,
+                               description: "ios or android",
+                                  optional: false)
+ 
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/firebase/lib/api.rb
+++ b/lib/fastlane/plugin/firebase/lib/api.rb
@@ -22,6 +22,7 @@ module Fastlane
 				@base_url = "https://console.firebase.google.com"
 				@sdk_url = "https://mobilesdk-pa.clients6.google.com/"
 				@login_url = "https://accounts.google.com/ServiceLogin"
+        @apikey_url = "https://apikeys.clients6.google.com/"
 
 				login(email, password)
 			end
@@ -197,6 +198,38 @@ module Fastlane
 				json_headers
 			end
 
+			def apikey_request_json(path, method = :get, parameters = Hash.new, headers = Hash.new, query = '')
+					begin
+					if method == :get then
+						parameters["key"] = @api_key
+						page = @agent.get("#{@apikey_url}#{path}", parameters, nil, headers.merge(@authorization_headers))
+					elsif method == :post then
+						headers['Content-Type'] = 'application/json'
+            puts "#{@apikey_url}#{path}?key=#{@api_key}"
+            puts parameters.to_json
+						page = @agent.post("#{@apikey_url}#{path}?key=#{@api_key}", parameters.to_json, headers.merge(@authorization_headers))
+					elsif method == :patch then
+						headers['Content-Type'] = 'application/json'
+						page = @agent.request_with_entity(
+              'patch', "#{@apikey_url}#{path}?key=#{@api_key}&#{query}", parameters.to_json, headers.merge(@authorization_headers)
+            )
+					elsif method == :delete then
+						page = @agent.delete("#{@apikey_url}#{path}?key=#{@api_key}", parameters, headers.merge(@authorization_headers))
+					end
+
+					JSON.parse(page.body)
+
+					rescue Mechanize::ResponseCodeError => e
+						code = e.response_code.to_i
+						if code >= 400 && code < 500 then
+							if body = JSON.parse(e.page.body) then
+								raise BadRequestError.new(body["error"]["message"], code)
+							end
+						end
+						UI.crash! e.page.body
+					end
+			end
+
 			def request_json(path, method = :get, parameters = Hash.new, headers = Hash.new)
 					begin
 					if method == :get then
@@ -332,6 +365,16 @@ module Fastlane
 
 				json = request_json("v1/projects/#{project_number}/clients/ios:#{bundle_id}:setAppStoreId", :post, parameters)
 			end
+
+      def get_apikey(project_number, api_key)
+				json = apikey_request_json("v1/projects/#{project_number}/apiKeys/#{api_key}", :get)
+      end
+
+      def update_apikey(project_number, api_key, update_mask, payload)
+        json = apikey_request_json(
+          "v1/projects/#{project_number}/apiKeys/#{api_key}", :patch, payload, Hash.new, "updateMask=#{update_mask}"
+        )
+      end
 		end
 	end
 end

--- a/lib/fastlane/plugin/firebase/lib/manager.rb
+++ b/lib/fastlane/plugin/firebase/lib/manager.rb
@@ -46,6 +46,8 @@ module Fastlane
 
 				if project = projects.select {|p| p["projectNumber"] == project_number }.first then
 					project
+				elsif project = projects.select {|p| p["displayName"] == project_number }.first then
+					project
 				else 
         	options = projects.map { |p| p["displayName"] }
         	index = select_index("Select project:", options)

--- a/lib/fastlane/plugin/firebase/version.rb
+++ b/lib/fastlane/plugin/firebase/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Firebase
-    VERSION = "0.2.3"
+    VERSION = "0.2.4"
   end
 end

--- a/lib/fastlane/plugin/firebase/version.rb
+++ b/lib/fastlane/plugin/firebase/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Firebase
-    VERSION = "0.2.4"
+    VERSION = "0.2.5"
   end
 end


### PR DESCRIPTION
@felipe-augusto , thanks for your great work on the fastlane-firebase-plugin.  I've extended it with a few new functions, and the ability to use a project name instead of a project id.  Any interest?

- Adds the ability to manipulate an API KEY to add android or ios restrictions (a Google Map API Key for example)
- Adds the ability to get the FCM Server Key